### PR TITLE
Create first workflows

### DIFF
--- a/.github/workflows/defining-outputs-test.yml
+++ b/.github/workflows/defining-outputs-test.yml
@@ -1,0 +1,26 @@
+name: Defining Outputs Intro
+
+on:
+    workflow_dispatch:
+    push:
+
+jobs:
+    job1:
+      runs-on: ubuntu-latest
+      # Map a step output to a job output
+      outputs:
+        output1: ${{ steps.step1.outputs.test }}
+        output2: ${{ steps.step2.outputs.test }}
+      steps:
+        - id: step1
+          run: echo "test=hello" >> "$GITHUB_OUTPUT"
+        - id: step2
+          run: echo "test=world" >> "$GITHUB_OUTPUT"
+    job2:
+      runs-on: ubuntu-latest
+      needs: job1
+      steps:
+        - env:
+            OUTPUT1: ${{needs.job1.outputs.output1}}
+            OUTPUT2: ${{needs.job1.outputs.output2}}
+          run: echo "$OUTPUT1 $OUTPUT2"

--- a/.github/workflows/find-file.yml
+++ b/.github/workflows/find-file.yml
@@ -1,0 +1,64 @@
+name: Deploy Storage Account
+on:
+    push:
+        paths:
+            - 'storage_accounts/**'
+
+permissions: write-all
+
+jobs:
+    job1:
+        name: Run PowerShell Script
+        runs-on: windows-latest
+        outputs:
+            output1: ${{ steps.findfile.outputs.jsonfile }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0 # Fetches the commit history to compare changes
+
+            - name: Find Added File
+              id: findfile
+              shell: pwsh
+              run: |
+                # Save the output of git diff to a variable
+                $diffOutput = git diff --name-only HEAD HEAD~1
+                echo "Diff Output: $diffOutput"
+                
+                $addedFiles = @()
+            
+                # Loop through each line of diffOutput
+                foreach ($line in $diffOutput -split "`n") {
+                    if ($line -match 'storage_accounts/') {
+                        $addedFiles += $line
+                    }
+                }
+                echo "Added Files: $addedFiles"
+
+                # Check if addedFiles is not empty
+                if ($addedFiles.Count -gt 0) {
+                    $fileName = $addedFiles -join ', '
+                    echo "jsonfile=test" >> "$GITHUB_OUTPUT"
+                    echo "File Name: $fileName"
+                } else {
+                    echo "No new files in 'storage_accounts/'"
+                }
+
+    job2:
+        needs: job1
+        name: Run PowerShell Script
+        runs-on: windows-latest
+        steps:
+          - uses: actions/checkout@v4
+            with:
+              fetch-depth: 0  # Fetches the commit history to compare changes        
+          - name: Script
+            shell: pwsh
+            env:
+                CLIENT_ID: ${{ secrets.CLIENT_ID }}
+                CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+                SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+                TENANT_ID: ${{ secrets.TENANT_ID }}
+                FILE_NAME: ${{ needs.job1.outputs.output1 }}
+            run: |
+                echo "File Name: $FILE_NAME"


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows: `Defining Outputs Intro` and `Deploy Storage Account`. The `Defining Outputs Intro` workflow is a basic example of defining outputs in a GitHub Actions workflow. The `Deploy Storage Account` workflow is designed to deploy a storage account when changes are made to the `storage_accounts` directory. It also includes a step to find and output the names of any new files added to the `storage_accounts` directory.