### PR TITLE
Update find-file.yml

### DIFF
--- a/.github/workflows/find-file.yml
+++ b/.github/workflows/find-file.yml
@@ -48,18 +48,13 @@ jobs:
         name: Print outputs in PowerShell script
         needs: job1
         runs-on: windows-latest
-        steps:
-            - name: Checkout Repository
-              uses: actions/checkout@v4
-              with:
-                fetch-depth: 0  # Fetches the commit history to compare changes        
-            - name: Script
-              shell: pwsh
-              env:
+        steps:     
+            - env:
                 # CLIENT_ID: ${{ secrets.CLIENT_ID }}
                 # CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
                 # SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
                 # TENANT_ID: ${{ secrets.TENANT_ID }}
                 FILE_NAME: ${{ needs.job1.outputs.fileName }}
+              shell: pwsh
               run: |
                 echo "File Name: $FILE_NAME"


### PR DESCRIPTION
This pull request includes a change in the `.github/workflows/find-file.yml` file. The change reorders the steps in the `jobs:` section, specifically, the `Checkout Repository` step has been removed and the `Script` step has been simplified. The `env:` and `shell: pwsh` lines have been moved above the `run:` line. The `fetch-depth: 0` line, which was used to fetch the commit history, has also been removed.